### PR TITLE
Fix prefix of hedgehog-tokyo

### DIFF
--- a/.well-known/mantela.json
+++ b/.well-known/mantela.json
@@ -118,7 +118,7 @@
             "identifier": "47abe85d-fe09-691d-f928-4f75b27a157f",
             "mantela": "https://rainyvillage.jp/mantela/mantela.json",
             "name": "hedgehog-tokyo",
-            "prefix": "２42"
+            "prefix": "242"
         },
         {
             "identifier": "5752ca4c-c828-4946-a8f3-7f8272206f2d",


### PR DESCRIPTION
全角の 2 が紛れ込んでいたので修正します。